### PR TITLE
Add pdc-mcp: MCP server for agent-driven brightness control

### DIFF
--- a/pdc-mcp/BrightnessTools.cs
+++ b/pdc-mcp/BrightnessTools.cs
@@ -1,0 +1,56 @@
+using System.ComponentModel;
+using ModelContextProtocol.Server;
+using pdc.DisplayApi;
+
+namespace pdc.Mcp;
+
+/// <summary>
+/// MCP tools that let an agent inspect displays and change their brightness.
+/// These wrap <see cref="DisplayApiService"/>; none of them write to stdout
+/// (which is reserved for the MCP protocol), so they build/return strings instead.
+/// </summary>
+[McpServerToolType]
+public static class BrightnessTools
+{
+    [McpServerTool(Name = "list_displays")]
+    [Description("List connected displays with their index and name. " +
+        "Philips monitors (name contains 'PHL') support precise DDC/CI brightness; " +
+        "use the returned index with set_brightness.")]
+    public static string ListDisplays()
+    {
+        DisplayApiService.InitDisplayInfo();
+
+        var names = DisplayApiService.displayNames;
+        if (names.Count == 0)
+        {
+            return "No displays were detected.";
+        }
+
+        var lines = names.Select((name, index) => $"index {index}: {name}");
+        return string.Join(Environment.NewLine, lines);
+    }
+
+    [McpServerTool(Name = "set_brightness")]
+    [Description("Set the brightness of a single display by its index (from list_displays). " +
+        "Brightness is a percentage from 0 to 100; out-of-range values are clamped.")]
+    public static string SetBrightness(
+        [Description("Display index as reported by list_displays")] int displayIndex,
+        [Description("Target brightness percentage, 0-100")] int brightness)
+    {
+        var clamped = Math.Clamp(brightness, 0, 100);
+        DisplayApiService.SetDisplayBrightnessIndividually(new[] { $"{displayIndex}:{clamped}" });
+        return $"Set display {displayIndex} brightness to {clamped}%.";
+    }
+
+    [McpServerTool(Name = "set_all_brightness")]
+    [Description("Set the same brightness on all displays at once. Philips monitors are set " +
+        "via DDC/CI; other displays via the OS backlight control. " +
+        "Brightness is a percentage from 0 to 100; out-of-range values are clamped.")]
+    public static string SetAllBrightness(
+        [Description("Target brightness percentage, 0-100")] int brightness)
+    {
+        var clamped = Math.Clamp(brightness, 0, 100);
+        DisplayApiService.SetAllDisplayBrightness(clamped);
+        return $"Set all displays to {clamped}%.";
+    }
+}

--- a/pdc-mcp/Program.cs
+++ b/pdc-mcp/Program.cs
@@ -1,0 +1,22 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+// MCP server for controlling display brightness via DDC/CI (VCP code 0x10),
+// reusing pdc's DisplayApiService. Communicates over stdio.
+//
+// IMPORTANT: with the stdio transport, stdout is the JSON-RPC channel. All
+// diagnostic logging must go to stderr, and tools must never write to stdout.
+var builder = Host.CreateApplicationBuilder(args);
+
+builder.Logging.AddConsole(options =>
+{
+    options.LogToStandardErrorThreshold = LogLevel.Trace;
+});
+
+builder.Services
+    .AddMcpServer()
+    .WithStdioServerTransport()
+    .WithToolsFromAssembly();
+
+await builder.Build().RunAsync();

--- a/pdc-mcp/pdc-mcp.csproj
+++ b/pdc-mcp/pdc-mcp.csproj
@@ -1,0 +1,33 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0-windows</TargetFramework>
+    <RootNamespace>pdc.Mcp</RootNamespace>
+    <AssemblyName>pdc-mcp</AssemblyName>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Version>0.1.0.0</Version>
+    <Product>pdc-mcp</Product>
+    <Description>MCP server exposing Philips display brightness control as agent tools</Description>
+
+    <!-- Single-file, self-contained publish (same shape as pdc). -->
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <SelfContained>true</SelfContained>
+    <PublishSingleFile>true</PublishSingleFile>
+    <EnableCompressionInSingleFile>true</EnableCompressionInSingleFile>
+    <DebugType>embedded</DebugType>
+    <SatelliteResourceLanguages>en</SatelliteResourceLanguages>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="ModelContextProtocol" Version="1.3.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- Reuse the existing DDC/CI + WMI brightness logic. -->
+    <ProjectReference Include="..\pdc\pdc.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/pdc.sln
+++ b/pdc.sln
@@ -12,20 +12,54 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Utils", "Utils", "{7BC69686
 		Utils\InsertIcons.exe = Utils\InsertIcons.exe
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "pdc-mcp", "pdc-mcp\pdc-mcp.csproj", "{D14083BE-AD1C-4DA7-BBCD-FA1AB2E7F1EB}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{1EFA7A0E-F3F5-4048-A742-1138807E7CE1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{1EFA7A0E-F3F5-4048-A742-1138807E7CE1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1EFA7A0E-F3F5-4048-A742-1138807E7CE1}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{1EFA7A0E-F3F5-4048-A742-1138807E7CE1}.Debug|x64.Build.0 = Debug|Any CPU
+		{1EFA7A0E-F3F5-4048-A742-1138807E7CE1}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{1EFA7A0E-F3F5-4048-A742-1138807E7CE1}.Debug|x86.Build.0 = Debug|Any CPU
 		{1EFA7A0E-F3F5-4048-A742-1138807E7CE1}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1EFA7A0E-F3F5-4048-A742-1138807E7CE1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1EFA7A0E-F3F5-4048-A742-1138807E7CE1}.Release|x64.ActiveCfg = Release|Any CPU
+		{1EFA7A0E-F3F5-4048-A742-1138807E7CE1}.Release|x64.Build.0 = Release|Any CPU
+		{1EFA7A0E-F3F5-4048-A742-1138807E7CE1}.Release|x86.ActiveCfg = Release|Any CPU
+		{1EFA7A0E-F3F5-4048-A742-1138807E7CE1}.Release|x86.Build.0 = Release|Any CPU
 		{982B9F68-C027-4F34-9034-BF4A2AC13A14}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{982B9F68-C027-4F34-9034-BF4A2AC13A14}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{982B9F68-C027-4F34-9034-BF4A2AC13A14}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{982B9F68-C027-4F34-9034-BF4A2AC13A14}.Debug|x64.Build.0 = Debug|Any CPU
+		{982B9F68-C027-4F34-9034-BF4A2AC13A14}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{982B9F68-C027-4F34-9034-BF4A2AC13A14}.Debug|x86.Build.0 = Debug|Any CPU
 		{982B9F68-C027-4F34-9034-BF4A2AC13A14}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{982B9F68-C027-4F34-9034-BF4A2AC13A14}.Release|Any CPU.Build.0 = Release|Any CPU
+		{982B9F68-C027-4F34-9034-BF4A2AC13A14}.Release|x64.ActiveCfg = Release|Any CPU
+		{982B9F68-C027-4F34-9034-BF4A2AC13A14}.Release|x64.Build.0 = Release|Any CPU
+		{982B9F68-C027-4F34-9034-BF4A2AC13A14}.Release|x86.ActiveCfg = Release|Any CPU
+		{982B9F68-C027-4F34-9034-BF4A2AC13A14}.Release|x86.Build.0 = Release|Any CPU
+		{D14083BE-AD1C-4DA7-BBCD-FA1AB2E7F1EB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D14083BE-AD1C-4DA7-BBCD-FA1AB2E7F1EB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D14083BE-AD1C-4DA7-BBCD-FA1AB2E7F1EB}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{D14083BE-AD1C-4DA7-BBCD-FA1AB2E7F1EB}.Debug|x64.Build.0 = Debug|Any CPU
+		{D14083BE-AD1C-4DA7-BBCD-FA1AB2E7F1EB}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{D14083BE-AD1C-4DA7-BBCD-FA1AB2E7F1EB}.Debug|x86.Build.0 = Debug|Any CPU
+		{D14083BE-AD1C-4DA7-BBCD-FA1AB2E7F1EB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D14083BE-AD1C-4DA7-BBCD-FA1AB2E7F1EB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D14083BE-AD1C-4DA7-BBCD-FA1AB2E7F1EB}.Release|x64.ActiveCfg = Release|Any CPU
+		{D14083BE-AD1C-4DA7-BBCD-FA1AB2E7F1EB}.Release|x64.Build.0 = Release|Any CPU
+		{D14083BE-AD1C-4DA7-BBCD-FA1AB2E7F1EB}.Release|x86.ActiveCfg = Release|Any CPU
+		{D14083BE-AD1C-4DA7-BBCD-FA1AB2E7F1EB}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Exposes display brightness control as MCP tools so AI agents can inspect displays and adjust brightness, reusing pdc's DisplayApiService (DDC/CI via dxva2.dll, WMI fallback).

- pdc-mcp.csproj: net10.0-windows console host, ModelContextProtocol 1.3.0, references pdc; single-file self-contained publish like pdc
- Program.cs: stdio MCP host (logs to stderr to keep stdout as the JSON-RPC channel)
- BrightnessTools.cs: list_displays, set_brightness, set_all_brightness (brightness clamped 0-100)

Verified: tools/list advertises all three with correct schemas; list_displays enumerates real monitors over MCP; server reports Connected in Claude Code.